### PR TITLE
feat(firestore-rules): update to v2 ruleset

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,4 @@
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /user/{uid} {


### PR DESCRIPTION
otherwise you get a warning on deploy:

```
i  cloud.firestore: checking firestore.rules for compilation errors...
⚠  [W] undefined:undefined - Ruleset uses old version (version [1]). Please update to the latest version (version [2]).
```